### PR TITLE
implementing BasicAuth for one username; fixes #96

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,6 +99,7 @@ type Web struct {
 	BasePath       string `default:"" desc:"Base path prefix for UI and API URLs"`
 	UIDir          string `required:"true" default:"ui/dist" desc:"User interface dir"`
 	GreetingFile   string `required:"true" default:"ui/greeting.html" desc:"Home page greeting HTML"`
+	AuthHeader     string `default:"" desc:"Authorization header for BasicAuth"`
 	MonitorVisible bool   `required:"true" default:"true" desc:"Show monitor tab in UI?"`
 	MonitorHistory int    `required:"true" default:"30" desc:"Monitor remembered messages"`
 	PProf          bool   `required:"true" default:"false" desc:"Expose profiling tools on /debug/pprof"`

--- a/pkg/server/web/handlers.go
+++ b/pkg/server/web/handlers.go
@@ -102,3 +102,17 @@ func spaTemplateHandler(tmpl *template.Template, basePath string,
 		}
 	})
 }
+
+// basicAuthMiddleware
+func basicAuthMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if len(rootConfig.Web.AuthHeader) > 0 {
+			if rootConfig.Web.AuthHeader != req.Header.Get("Authorization") {
+				w.Header().Set("WWW-Authenticate", `Basic realm="Restricted by INBUCKET_WEB_AUTHHEADER variable"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+		}
+		h.ServeHTTP(w, req)
+	})
+}

--- a/pkg/server/web/server.go
+++ b/pkg/server/web/server.go
@@ -41,6 +41,7 @@ var (
 )
 
 func init() {
+	Router.Use(basicAuthMiddleware)
 	m := expvar.NewMap("http")
 	m.Set("WebSocketConnectsCurrent", ExpWebSocketConnectsCurrent)
 }


### PR DESCRIPTION
For example, this value matches the username `foo` and password `bar`:

    export INBUCKET_WEB_AUTHHEADER="Basic Zm9vOmJhcg=="